### PR TITLE
fixed-Drush-Link-install.md

### DIFF
--- a/source/content/terminus/02-install.md
+++ b/source/content/terminus/02-install.md
@@ -66,7 +66,7 @@ Terminus does not work with the following platforms:
 
 ### Recommended Packages
 
-- [Drush](http://docs.drush.org/en/master/install/). This is useful if you need to run Drush commands that are incompatible with Terminus.
+- [Drush]( https://docs.drush.org/en/8.x/install/). This is useful if you need to run Drush commands that are incompatible with Terminus.
 - [WP-CLI](http://wp-cli.org/). This is useful if you need to run WP-CLI commands that are incompatible with Terminus.
 
 ## Install Terminus


### PR DESCRIPTION
Fixed #8712 updated the Drush link which was broken
Closes #

## Summary

**[Doc Install and Update Terminus](https://docs.pantheon.io/doc-title)** - <Enter a one sentence summation of the pertinent changes (including not-yet-completed work) provided by this PR.>

## Effect

Fixed the broken link to Drush doc under the [Recommended Packages](https://docs.pantheon.io/terminus/install#recommended-packages)

The following changes are already committed:

*
*

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
